### PR TITLE
キーワード検索機能・並び替え機能の追加

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -255,7 +255,7 @@ li span {
 }
 
 .disabled-button {
-  background: #666;
+  background: #666 !important;
   color: #ffffff;
   cursor: not-allowed !important;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -248,6 +248,44 @@ li span {
   cursor: not-allowed !important;
 }
 
+.search {
+  margin-left: 10%;
+  align-items: center;
+}
+#searchInput {
+  background-color: white;
+  border: 1px solid black;
+  border-radius: 5px;
+  line-height: 1.5;
+  padding-left: 5px;
+  width: 20rem;
+}
+
+#searchButton {
+  background-color: #121212;
+  color: white;
+  border-radius: 5px;
+  border: none;
+  padding: 5px;
+  cursor: pointer;
+  margin-left: 10px;
+  font-size: 1.2rem;
+}
+
+.sort {
+  margin-top: 10px;
+  margin-left: 10%;
+  align-items: center;
+}
+#sortSelect {
+  appearance: menulist-button;
+  background-color: white;
+  border: 1px solid black;
+  border-radius: 5px;
+  line-height: 1.5;
+  padding: 3px;
+}
+
 @media screen and (max-width: 800px) {
   div {
     flex-direction: column;
@@ -298,6 +336,19 @@ li span {
   .postContent {
     align-items: flex-start;
   }
+
+  #postButton {
+    width: fit-content;
+    padding: 3px;
+  }
+
+  .search {
+    flex-direction: row;
+  }
+
+  .sort {
+    flex-direction: row;
+  }
 }
 
 @media screen and (max-width: 500px) {
@@ -347,8 +398,31 @@ li span {
     margin: 1px;
   }
 
+  #postButton {
+    width: auto;
+    padding: 5px;
+  }
+
+  #postButtonWrapper {
+    width: fit-content;
+  }
+
   li {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .search {
+    flex-direction: column;
+  }
+
+  #searchButton {
+    margin-top: 5px;
+  }
+
+  .sort {
+    flex-direction: column;
+    font-size: 1rem;
+    padding: 2px;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -261,7 +261,11 @@ li span {
 }
 
 .search {
+  display: block;
   margin-left: 10%;
+}
+
+.searchContent {
   align-items: center;
 }
 #searchInput {

--- a/css/style.css
+++ b/css/style.css
@@ -196,6 +196,18 @@ li span {
   flex: none;
 }
 
+#resetButton {
+  margin-left: 10px;
+  background: gray;
+  color: white;
+  border-radius: 5px;
+  border: black solid 1px;
+  padding: 3px;
+  cursor: pointer;
+  flex: none;
+  font-size: 1.3rem;
+}
+
 #paginationContainer {
   display: flex;
   justify-content: center;
@@ -273,7 +285,7 @@ li span {
 }
 
 .sort {
-  margin-top: 10px;
+  margin-bottom: 10px;
   margin-left: 10%;
   align-items: center;
 }
@@ -284,6 +296,11 @@ li span {
   border-radius: 5px;
   line-height: 1.5;
   padding: 3px;
+}
+
+mark {
+  background-color: yellow;
+  font-weight: bold;
 }
 
 @media screen and (max-width: 800px) {
@@ -338,6 +355,11 @@ li span {
   }
 
   #postButton {
+    width: fit-content;
+    padding: 3px;
+  }
+
+  #resetButton {
     width: fit-content;
     padding: 3px;
   }
@@ -401,6 +423,13 @@ li span {
   #postButton {
     width: auto;
     padding: 5px;
+  }
+
+  #resetButton {
+    width: fit-content;
+    padding: 3px;
+    font-size: 1rem;
+    margin: 5px 0;
   }
 
   #postButtonWrapper {

--- a/index.html
+++ b/index.html
@@ -27,6 +27,19 @@
       </div>
     </div>
     <div class="separator"></div>
+    <div class="search">
+      <label for="searchInput">キーワード検索：</label>
+      <input type="text" id="searchInput" placeholder="キーワードを入力">
+      <button id="searchButton">検索</button>
+    </div>
+    <div class="sort">
+      <label for="sortSelect">並び替え：</label>
+      <select id="sortSelect">
+        <option value="newest">新しい順</option>
+        <option value="oldest">古い順</option>
+      </select>
+    </div>
+    <div class="separator"></div>
     <div class="posts">
       <ul id="postList"></ul>
       <div id="paginationContainer">

--- a/index.html
+++ b/index.html
@@ -28,10 +28,12 @@
     </div>
     <div class="separator"></div>
     <div class="search">
-      <label for="searchInput">キーワード検索：</label>
-      <input type="text" id="searchInput" placeholder="キーワードを入力">
-      <button id="searchButton">検索</button>
-      <button id="resetButton">検索結果リセット</button>
+      <div class="searchContent">
+        <label for="searchInput">キーワード検索：</label>
+        <input type="text" id="searchInput" placeholder="キーワードを入力">
+        <button id="searchButton">検索</button>
+        <button id="resetButton">検索結果リセット</button>
+      </div>
     </div>
     <div class="separator"></div>
     <div class="sort">

--- a/index.html
+++ b/index.html
@@ -31,7 +31,9 @@
       <label for="searchInput">キーワード検索：</label>
       <input type="text" id="searchInput" placeholder="キーワードを入力">
       <button id="searchButton">検索</button>
+      <button id="resetButton">検索結果リセット</button>
     </div>
+    <div class="separator"></div>
     <div class="sort">
       <label for="sortSelect">並び替え：</label>
       <select id="sortSelect">
@@ -39,7 +41,6 @@
         <option value="oldest">古い順</option>
       </select>
     </div>
-    <div class="separator"></div>
     <div class="posts">
       <ul id="postList"></ul>
       <div id="paginationContainer">

--- a/js/index.js
+++ b/js/index.js
@@ -30,7 +30,7 @@ document.addEventListener("DOMContentLoaded", ()=>{
   const postSearch = new PostSearch(htmlIds, postRepository, postListController);
   new PostDelete(postRepository, postListController, postSearch);
   new PostEdit(postRepository, postListController, postSearch);
-  new PostSort(postRepository, postListController);
+  new PostSort(postRepository, postListController, postSearch);
 
   if(userNameRepository.hasUserName()){
     postCreate.userName.value = userNameRepository.getUserName();

--- a/js/index.js
+++ b/js/index.js
@@ -6,6 +6,7 @@ import { PostEdit } from './parts/postEdit.js';
 import { UserNameRepository } from "./repositories/userNameRepository.js";
 import { runMigrations } from "./migration/runMigrations.js";
 import { PostSearch } from "./parts/postSearch.js";
+import { PostSort } from "./parts/postSort.js";
 
 document.addEventListener("DOMContentLoaded", ()=>{
   const htmlIds = {
@@ -29,6 +30,7 @@ document.addEventListener("DOMContentLoaded", ()=>{
   new PostDelete(postRepository, postListController);
   new PostEdit(postRepository, postListController);
   new PostSearch(htmlIds, postRepository, postListController);
+  new PostSort(postRepository, postListController);
 
   if(userNameRepository.hasUserName()){
     postCreate.userName.value = userNameRepository.getUserName();

--- a/js/index.js
+++ b/js/index.js
@@ -27,9 +27,9 @@ document.addEventListener("DOMContentLoaded", ()=>{
   const userNameRepository = new UserNameRepository();
   const postListController = new PostListController(htmlIds, postRepository);
   const postCreate = new PostCreate(htmlIds, postRepository, postListController, userNameRepository );
-  new PostDelete(postRepository, postListController);
-  new PostEdit(postRepository, postListController);
-  new PostSearch(htmlIds, postRepository, postListController);
+  const postSearch = new PostSearch(htmlIds, postRepository, postListController);
+  new PostDelete(postRepository, postListController, postSearch);
+  new PostEdit(postRepository, postListController, postSearch);
   new PostSort(postRepository, postListController);
 
   if(userNameRepository.hasUserName()){

--- a/js/index.js
+++ b/js/index.js
@@ -5,6 +5,7 @@ import { PostDelete } from './parts/postDelete.js';
 import { PostEdit } from './parts/postEdit.js';
 import { UserNameRepository } from "./repositories/userNameRepository.js";
 import { runMigrations } from "./migration/runMigrations.js";
+import { PostSearch } from "./parts/postSearch.js";
 
 document.addEventListener("DOMContentLoaded", ()=>{
   const htmlIds = {
@@ -14,7 +15,10 @@ document.addEventListener("DOMContentLoaded", ()=>{
     postButtonId: "postButton",
     prevButtonId: "prevBtn",
     paginateId: "pagination",
-    nextButtonId: "nextBtn"
+    nextButtonId: "nextBtn",
+    searchInputId: "searchInput",
+    searchButtonId: "searchButton",
+    resetButtonId: "resetButton"
   };
   const postRepository = new PostRepository();
   runMigrations(postRepository);
@@ -24,6 +28,7 @@ document.addEventListener("DOMContentLoaded", ()=>{
   const postCreate = new PostCreate(htmlIds, postRepository, postListController, userNameRepository );
   new PostDelete(postRepository, postListController);
   new PostEdit(postRepository, postListController);
+  new PostSearch(htmlIds, postRepository, postListController);
 
   if(userNameRepository.hasUserName()){
     postCreate.userName.value = userNameRepository.getUserName();

--- a/js/parts/postCreate.js
+++ b/js/parts/postCreate.js
@@ -47,7 +47,7 @@ export class PostCreate {
     this.postListController.allPosts = this.postRepository.getAllPosts();
     const totalPages = this.postListController.paginator.totalPages(this.postListController.allPosts);
     this.postListController.refreshPostList(totalPages);
-    this.commentInput.value = "";
+    PostViewRenderer.clearValueElem(this.commentInput);
   }
 
   setupEventListeners(){

--- a/js/parts/postDelete.js
+++ b/js/parts/postDelete.js
@@ -1,9 +1,10 @@
 import { PostViewRenderer } from "../view/PostViewRenderer.js";
 
 export class PostDelete {
-  constructor(postRepository, postListController){
+  constructor(postRepository, postListController, postSearch){
     this.postRepository = postRepository;
     this.postListController = postListController;
+    this.postSearch = postSearch;
     this.postList = this.postListController.postList;
     this.setupEventListeners();
   }
@@ -13,6 +14,10 @@ export class PostDelete {
     liElement.remove();
     if(!this.postRepository.hasComments()){
       this.postRepository.clearCounter();
+    }
+    if(this.postSearch.isSearchMode){
+      this.postSearch.searchPosts();
+      return;
     }
     this.postListController.allPosts = this.postRepository.getAllPosts();
     const totalPages = this.postListController.paginator.totalPages(this.postListController.allPosts);

--- a/js/parts/postEdit.js
+++ b/js/parts/postEdit.js
@@ -2,10 +2,11 @@ import { PostValidation } from "../validation/postValidation.js";
 import { PostViewRenderer } from "../view/PostViewRenderer.js";
 
 export class PostEdit {
-  constructor(postRepository, postListController){
+  constructor(postRepository, postListController, postSearch){
     this.postRepository = postRepository;
     this.postListController = postListController;
     this.postList = this.postListController.postList;
+    this.postSearch = postSearch;
     this.setupEventListeners();
   }
 
@@ -37,6 +38,11 @@ export class PostEdit {
 
     this.postRepository.updateComment(postKey, editUserName, editComment);
     PostViewRenderer.switchTextMode(liElement);
+    if(this.postSearch.isSearchMode){
+      this.postSearch.searchPosts();
+      PostViewRenderer.switchEnabledButtons();
+      return;
+    }
     this.postListController.refreshPostList(this.postListController.currentPage);
   }
 
@@ -61,6 +67,11 @@ export class PostEdit {
         }
       }
       if(PostViewRenderer.isCancelButton(target)) {
+        if(this.postSearch.isSearchMode){
+          this.postSearch.searchPosts();
+          PostViewRenderer.switchEnabledButtons();
+          return;
+        }
         this.postListController.refreshPostList(this.postListController.currentPage);
       }
     });

--- a/js/parts/postEdit.js
+++ b/js/parts/postEdit.js
@@ -37,12 +37,13 @@ export class PostEdit {
     if(!isValid) return;
 
     this.postRepository.updateComment(postKey, editUserName, editComment);
-    PostViewRenderer.switchTextMode(liElement);
+
     if(this.postSearch.isSearchMode){
-      this.postSearch.searchPosts();
-      PostViewRenderer.switchEnabledButtons();
+      PostViewRenderer.switchTextMode(liElement, this.postSearch.keyword);
+      PostViewRenderer.switchEnabledAllButtons();
       return;
     }
+    PostViewRenderer.switchTextMode(liElement);
     this.postListController.refreshPostList(this.postListController.currentPage);
   }
 

--- a/js/parts/postSearch.js
+++ b/js/parts/postSearch.js
@@ -8,6 +8,7 @@ export class PostSearch {
     this.searchButton = PostViewRenderer.getHtmlElem(htmlIds.searchButtonId);
     this.resetButton = PostViewRenderer.getHtmlElem(htmlIds.resetButtonId);
     this.setupEventListeners();
+    this.isSearchMode = false;
   }
 
   searchPosts(){
@@ -16,6 +17,7 @@ export class PostSearch {
       alert("検索キーワードを入力してください。");
       return;
     }
+    this.isSearchMode = true;
     const allPosts = this.postRepository.getAllPosts();
     const filteredPosts = allPosts.filter(post => {
       const userName = post.userName || "";
@@ -50,6 +52,7 @@ export class PostSearch {
       this.searchPosts();
     });
     this.resetButton.addEventListener("click", () => {
+      this.isSearchMode = false;
       this.postListController.refreshPostList(this.postListController.currentPage);
       this.searchInput.value = "";
       PostViewRenderer.ShowPagination();

--- a/js/parts/postSearch.js
+++ b/js/parts/postSearch.js
@@ -28,6 +28,7 @@ export class PostSearch {
       return;
     }
     this.postListController.postList.innerHTML = "";
+    this.postListController.getSortedPosts(filteredPosts);
     filteredPosts.forEach(post => {
       if(!post.updatedAt) {
         post.updatedAt = "----/--/-- --:--:--";

--- a/js/parts/postSearch.js
+++ b/js/parts/postSearch.js
@@ -17,29 +17,25 @@ export class PostSearch {
     const searchContent = PostViewRenderer.getSearchContent();
     PostViewRenderer.initErrorMessageIntoSearchElem();
     PostViewRenderer.addErrorMessageIntoSearch();
-    let isValid = true;
     const postSearchValidation = PostSearchValidation.validateSearchKeyword(keyword);
     if (!postSearchValidation.isValid) {
       PostViewRenderer.showErrorMessage(
         PostViewRenderer.getErrorCommentElem(searchContent),
         postSearchValidation.errorMessage
       );
-      isValid = false;
+      return;
     }
     const allPosts = this.postRepository.getAllPosts();
     const filteredPosts = allPosts.filter(post => {
       const userName = post.userName || "";
       return userName.includes(keyword) || post.comment.includes(keyword)
     });
-    const notSearchPostsValidation = PostSearchValidation.validateNotSearchPosts(filteredPosts);
-    if(!notSearchPostsValidation.isValid) {
-      PostViewRenderer.showErrorMessage(
-        PostViewRenderer.getErrorCommentElem(searchContent),
-        notSearchPostsValidation.errorMessage
-      );
-      isValid = false;
+
+    if(filteredPosts.length === 0) {
+      PostViewRenderer.clearInnerHTML(this.postListController.postList);
+      PostViewRenderer.addSearchResultMessage(this.postListController.postList);
+      return;
     }
-    if(!isValid) return;
 
     this.isSearchMode = true;
     PostViewRenderer.clearInnerHTML(this.postListController.postList);

--- a/js/parts/postSearch.js
+++ b/js/parts/postSearch.js
@@ -1,0 +1,58 @@
+import { PostViewRenderer } from "../view/PostViewRenderer.js";
+
+export class PostSearch {
+  constructor(htmlIds, postRepository, postListController){
+    this.postRepository = postRepository;
+    this.postListController = postListController;
+    this.searchInput = PostViewRenderer.getHtmlElem(htmlIds.searchInputId);
+    this.searchButton = PostViewRenderer.getHtmlElem(htmlIds.searchButtonId);
+    this.resetButton = PostViewRenderer.getHtmlElem(htmlIds.resetButtonId);
+    this.setupEventListeners();
+  }
+
+  searchPosts(){
+    const keyword = this.searchInput.value.trim();
+    if (!keyword) {
+      alert("検索キーワードを入力してください。");
+      return;
+    }
+    const allPosts = this.postRepository.getAllPosts();
+    const filteredPosts = allPosts.filter(post => {
+      const userName = post.userName || "";
+      return userName.includes(keyword) || post.comment.includes(keyword)
+    });
+    if(filteredPosts.length === 0) {
+      alert("指定されたキーワードに該当する投稿は見つかりませんでした。");
+      return;
+    }
+    this.postListController.postList.innerHTML = "";
+    filteredPosts.forEach(post => {
+      if(!post.updatedAt) {
+        post.updatedAt = "----/--/-- --:--:--";
+      }
+      if(!post.userName) {
+        post.userName = "名無し";
+      }
+      this.postListController.addPostToList(
+        post.postKey,
+        post.userName,
+        post.comment,
+        post.postNum,
+        post.updatedAt,
+        keyword
+      );
+    });
+    PostViewRenderer.HiddenPagination();
+  }
+
+  setupEventListeners(){
+    this.searchButton.addEventListener("click", () => {
+      this.searchPosts();
+    });
+    this.resetButton.addEventListener("click", () => {
+      this.postListController.refreshPostList(this.postListController.currentPage);
+      this.searchInput.value = "";
+      PostViewRenderer.ShowPagination();
+    });
+  }
+}

--- a/js/parts/postSearch.js
+++ b/js/parts/postSearch.js
@@ -10,14 +10,15 @@ export class PostSearch {
     this.resetButton = PostViewRenderer.getHtmlElem(htmlIds.resetButtonId);
     this.setupEventListeners();
     this.isSearchMode = false;
+    this.keyword = "";
   }
 
   searchPosts(){
-    const keyword = this.searchInput.value.trim();
+    this.keyword = this.searchInput.value.trim();
     const searchContent = PostViewRenderer.getSearchContent();
     PostViewRenderer.initErrorMessageIntoSearchElem();
     PostViewRenderer.addErrorMessageIntoSearch();
-    const postSearchValidation = PostSearchValidation.validateSearchKeyword(keyword);
+    const postSearchValidation = PostSearchValidation.validateSearchKeyword(this.keyword);
     if (!postSearchValidation.isValid) {
       PostViewRenderer.showErrorMessage(
         PostViewRenderer.getErrorCommentElem(searchContent),
@@ -28,7 +29,7 @@ export class PostSearch {
     const allPosts = this.postRepository.getAllPosts();
     const filteredPosts = allPosts.filter(post => {
       const userName = post.userName || "";
-      return userName.includes(keyword) || post.comment.includes(keyword)
+      return userName.includes(this.keyword) || post.comment.includes(this.keyword)
     });
 
     if(filteredPosts.length === 0) {
@@ -48,7 +49,7 @@ export class PostSearch {
         post.comment,
         post.postNum,
         post.updatedAt,
-        keyword
+        this.keyword
       );
     });
     PostViewRenderer.HiddenPagination();

--- a/js/parts/postSearch.js
+++ b/js/parts/postSearch.js
@@ -1,3 +1,4 @@
+import { PostSearchValidation } from "../validation/postSearchValidation.js";
 import { PostViewRenderer } from "../view/PostViewRenderer.js";
 
 export class PostSearch {
@@ -13,20 +14,34 @@ export class PostSearch {
 
   searchPosts(){
     const keyword = this.searchInput.value.trim();
-    if (!keyword) {
-      alert("検索キーワードを入力してください。");
-      return;
+    const searchContent = PostViewRenderer.getSearchContent();
+    PostViewRenderer.initErrorMessageIntoSearchElem();
+    PostViewRenderer.addErrorMessageIntoSearch();
+    let isValid = true;
+    const postSearchValidation = PostSearchValidation.validateSearchKeyword(keyword);
+    if (!postSearchValidation.isValid) {
+      PostViewRenderer.showErrorMessage(
+        PostViewRenderer.getErrorCommentElem(searchContent),
+        postSearchValidation.errorMessage
+      );
+      isValid = false;
     }
-    this.isSearchMode = true;
     const allPosts = this.postRepository.getAllPosts();
     const filteredPosts = allPosts.filter(post => {
       const userName = post.userName || "";
       return userName.includes(keyword) || post.comment.includes(keyword)
     });
-    if(filteredPosts.length === 0) {
-      alert("指定されたキーワードに該当する投稿は見つかりませんでした。");
-      return;
+    const notSearchPostsValidation = PostSearchValidation.validateNotSearchPosts(filteredPosts);
+    if(!notSearchPostsValidation.isValid) {
+      PostViewRenderer.showErrorMessage(
+        PostViewRenderer.getErrorCommentElem(searchContent),
+        notSearchPostsValidation.errorMessage
+      );
+      isValid = false;
     }
+    if(!isValid) return;
+
+    this.isSearchMode = true;
     this.postListController.postList.innerHTML = "";
     this.postListController.getSortedPosts(filteredPosts);
     filteredPosts.forEach(post => {
@@ -56,6 +71,7 @@ export class PostSearch {
       this.isSearchMode = false;
       this.postListController.refreshPostList(this.postListController.currentPage);
       this.searchInput.value = "";
+      PostViewRenderer.initErrorMessageIntoSearchElem();
       PostViewRenderer.ShowPagination();
     });
   }

--- a/js/parts/postSearch.js
+++ b/js/parts/postSearch.js
@@ -42,15 +42,10 @@ export class PostSearch {
     if(!isValid) return;
 
     this.isSearchMode = true;
-    this.postListController.postList.innerHTML = "";
+    PostViewRenderer.clearInnerHTML(this.postListController.postList);
     this.postListController.getSortedPosts(filteredPosts);
     filteredPosts.forEach(post => {
-      if(!post.updatedAt) {
-        post.updatedAt = "----/--/-- --:--:--";
-      }
-      if(!post.userName) {
-        post.userName = "名無し";
-      }
+      this.postListController.setDefaultPostValues(post);
       this.postListController.addPostToList(
         post.postKey,
         post.userName,
@@ -70,7 +65,7 @@ export class PostSearch {
     this.resetButton.addEventListener("click", () => {
       this.isSearchMode = false;
       this.postListController.refreshPostList(this.postListController.currentPage);
-      this.searchInput.value = "";
+      PostViewRenderer.clearValueElem(this.searchInput);
       PostViewRenderer.initErrorMessageIntoSearchElem();
       PostViewRenderer.ShowPagination();
     });

--- a/js/parts/postSort.js
+++ b/js/parts/postSort.js
@@ -1,9 +1,11 @@
+import { PostViewRenderer } from "../view/PostViewRenderer.js";
+
 export class PostSort {
   constructor(postRepository, postListController, postSearch){
     this.postRepository = postRepository;
     this.postListController = postListController;
     this.postSearch = postSearch;
-    this.sortSelect = document.getElementById("sortSelect");
+    this.sortSelect = PostViewRenderer.getSortSeletectElem();
     this.setupEventListeners();
   }
 

--- a/js/parts/postSort.js
+++ b/js/parts/postSort.js
@@ -1,0 +1,20 @@
+export class PostSort {
+  constructor(postRepository, postListController){
+    this.postRepository = postRepository;
+    this.postListController = postListController;
+    this.sortSelect = document.getElementById("sortSelect");
+    this.setupEventListeners();
+  }
+
+  handleSortChange(){
+    const selected = this.sortSelect.value;
+    this.postListController.setSortOrder(selected);
+    this.postListController.refreshPostList(this.postListController.currentPage);
+  }
+
+  setupEventListeners(){
+    this.sortSelect.addEventListener("change", () => {
+      this.handleSortChange();
+    });
+  }
+}

--- a/js/parts/postSort.js
+++ b/js/parts/postSort.js
@@ -1,7 +1,8 @@
 export class PostSort {
-  constructor(postRepository, postListController){
+  constructor(postRepository, postListController, postSearch){
     this.postRepository = postRepository;
     this.postListController = postListController;
+    this.postSearch = postSearch;
     this.sortSelect = document.getElementById("sortSelect");
     this.setupEventListeners();
   }
@@ -9,6 +10,10 @@ export class PostSort {
   handleSortChange(){
     const selected = this.sortSelect.value;
     this.postListController.setSortOrder(selected);
+    if(this.postSearch.isSearchMode){
+      this.postSearch.searchPosts();
+      return;
+    }
     this.postListController.refreshPostList(this.postListController.currentPage);
   }
 

--- a/js/postListController.js
+++ b/js/postListController.js
@@ -50,15 +50,10 @@ export class PostListController{
 
   loadCurrentPagePosts(page){
     this.currentPage = page;
-    this.postList.innerHTML = "";
+    PostViewRenderer.clearInnerHTML(this.postList);
     const paginatedPosts = this.paginator.getCurrentPagePosts(page, this.allPosts);
     paginatedPosts.forEach( post => {
-      if(!post.updatedAt) {
-        post.updatedAt = "----/--/-- --:--:--";
-      }
-      if(!post.userName) {
-        post.userName = "名無し";
-      }
+      this.setDefaultPostValues(post);
       this.addPostToList(post.postKey, post.userName, post.comment, post.postNum, post.updatedAt);
     });
   }
@@ -81,6 +76,15 @@ export class PostListController{
       return posts.sort((a, b) => b.postNum - a.postNum);
     } else {
       return posts.sort((a, b) => a.postNum - b.postNum);
+    }
+  }
+
+  setDefaultPostValues(post){
+    if(!post.updatedAt) {
+      post.updatedAt = "----/--/-- --:--:--";
+    }
+    if(!post.userName) {
+      post.userName = "名無し";
     }
   }
 }

--- a/js/postListController.js
+++ b/js/postListController.js
@@ -64,7 +64,8 @@ export class PostListController{
   }
 
   refreshPostList(page){
-    this.allPosts = this.getSortedPosts();
+    const posts = this.postRepository.getAllPosts();
+    this.allPosts = this.getSortedPosts(posts);
     this.currentPage = page;
     this.loadCurrentPagePosts(this.currentPage);
     this.paginator.updatePostPage(this.allPosts, this.currentPage);
@@ -75,8 +76,7 @@ export class PostListController{
     this.sortOrder = order;
   }
 
-  getSortedPosts() {
-    const posts = this.postRepository.getAllPosts();
+  getSortedPosts(posts) {
     if (this.sortOrder === "oldest") {
       return posts.sort((a, b) => b.postNum - a.postNum);
     } else {

--- a/js/postListController.js
+++ b/js/postListController.js
@@ -21,7 +21,7 @@ export class PostListController{
     this.refreshPostList(this.currentPage);
   }
 
-  addPostToList(key, userName, comment, postNum, time){
+  addPostToList(key, userName, comment, postNum, time, keyWord = ""){
     const li = document.createElement('li');
     const postContent = document.createElement('div');
     postContent.className = 'postContent';
@@ -29,9 +29,9 @@ export class PostListController{
     postText.className = 'postText';
 
     const spanTime = PostViewRenderer.createSpanTime(time);
-    const spanUsername = PostViewRenderer.createSpanUserName(userName);
+    const spanUsername = PostViewRenderer.createSpanUserName(userName, keyWord);
     const spanKey = PostViewRenderer.createSpanKey(postNum);
-    const spanComment = PostViewRenderer.createSpanComment(comment);
+    const spanComment = PostViewRenderer.createSpanComment(comment, keyWord);
     const editButton = PostViewRenderer.createEditButton(key);
     const deleteButton = PostViewRenderer.createDeleteButton(key);
   

--- a/js/postListController.js
+++ b/js/postListController.js
@@ -72,11 +72,25 @@ export class PostListController{
   }
 
   getSortedPosts(posts) {
-    if (this.sortOrder === "oldest") {
-      return posts.sort((a, b) => b.postNum - a.postNum);
-    } else {
-      return posts.sort((a, b) => a.postNum - b.postNum);
-    }
+    return posts.sort((a, b) => {
+      const aHasDate = a.createdAt && a.createdAt !== "";
+      const bHasDate = b.createdAt && b.createdAt !== "";
+
+      if (!aHasDate && !bHasDate) {
+        return this.sortOrder === "oldest"
+          ? b.postNum - a.postNum
+          : a.postNum - b.postNum;
+      }
+      if (!aHasDate) return this.sortOrder === "oldest" ? 1 : -1;
+      if (!bHasDate) return this.sortOrder === "oldest" ? -1 : 1;
+
+      const aDate = new Date(a.createdAt);
+      const bDate = new Date(b.createdAt);
+  
+      return this.sortOrder === "oldest"
+        ? bDate - aDate
+        : aDate - bDate;
+    });
   }
 
   setDefaultPostValues(post){

--- a/js/postListController.js
+++ b/js/postListController.js
@@ -18,6 +18,7 @@ export class PostListController{
     );
     this.allPosts = this.postRepository.getAllPosts();
     this.currentPage = this.paginator.totalPages(this.allPosts);
+    this.sortOrder = "newest";
     this.refreshPostList(this.currentPage);
   }
 
@@ -63,10 +64,23 @@ export class PostListController{
   }
 
   refreshPostList(page){
-    this.allPosts = this.postRepository.getAllPosts();
+    this.allPosts = this.getSortedPosts();
     this.currentPage = page;
     this.loadCurrentPagePosts(this.currentPage);
     this.paginator.updatePostPage(this.allPosts, this.currentPage);
     PostViewRenderer.switchEnabledPostButton();
+  }
+
+  setSortOrder(order) {
+    this.sortOrder = order;
+  }
+
+  getSortedPosts() {
+    const posts = this.postRepository.getAllPosts();
+    if (this.sortOrder === "oldest") {
+      return posts.sort((a, b) => b.postNum - a.postNum);
+    } else {
+      return posts.sort((a, b) => a.postNum - b.postNum);
+    }
   }
 }

--- a/js/postListController.js
+++ b/js/postListController.js
@@ -69,6 +69,8 @@ export class PostListController{
     this.loadCurrentPagePosts(this.currentPage);
     this.paginator.updatePostPage(this.allPosts, this.currentPage);
     PostViewRenderer.switchEnabledPostButton();
+    PostViewRenderer.switchEnabledSearchButton();
+    PostViewRenderer.switchEnabledResetButton();
   }
 
   setSortOrder(order) {

--- a/js/postListController.js
+++ b/js/postListController.js
@@ -68,9 +68,7 @@ export class PostListController{
     this.currentPage = page;
     this.loadCurrentPagePosts(this.currentPage);
     this.paginator.updatePostPage(this.allPosts, this.currentPage);
-    PostViewRenderer.switchEnabledPostButton();
-    PostViewRenderer.switchEnabledSearchButton();
-    PostViewRenderer.switchEnabledResetButton();
+    PostViewRenderer.switchEnabledButtons();
   }
 
   setSortOrder(order) {

--- a/js/repositories/postRepository.js
+++ b/js/repositories/postRepository.js
@@ -90,7 +90,6 @@ export class PostRepository {
       if(postKey && postKey.startsWith(this.#config.commentPrefix)){
         const comment = this.getComment(postKey);
         const postNum = this.getPostNumberFromKey(postKey);
-        const createdAt = this.getCommentTime(postKey);
         const userName = this.getUserName(postKey);
         const updatedAt = this.getCommentUpdatedTime(postKey);
         posts.push({ postKey, comment, postNum, userName, updatedAt });

--- a/js/repositories/postRepository.js
+++ b/js/repositories/postRepository.js
@@ -91,8 +91,9 @@ export class PostRepository {
         const comment = this.getComment(postKey);
         const postNum = this.getPostNumberFromKey(postKey);
         const userName = this.getUserName(postKey);
+        const createdAt = this.getCommentTime(postKey);
         const updatedAt = this.getCommentUpdatedTime(postKey);
-        posts.push({ postKey, comment, postNum, userName, updatedAt });
+        posts.push({ postKey, comment, postNum, userName, createdAt, updatedAt });
       }
     }
     return posts;

--- a/js/repositories/postRepository.js
+++ b/js/repositories/postRepository.js
@@ -95,7 +95,6 @@ export class PostRepository {
         posts.push({ postKey, comment, postNum, userName, updatedAt });
       }
     }
-    posts.sort((a,b) => a.postNum - b.postNum);
     return posts;
   }
 

--- a/js/validation/postSearchValidation.js
+++ b/js/validation/postSearchValidation.js
@@ -8,14 +8,4 @@ export class PostSearchValidation {
     }
     return { isValid: true };
   }
-
-  static validateNotSearchPosts(filteredPosts) {
-    if (filteredPosts.length === 0) {
-      return {
-        isValid: false,
-        errorMessage: "指定されたキーワードに該当する投稿は見つかりませんでした。"
-      };
-    }
-    return { isValid: true };
-  }
 }

--- a/js/validation/postSearchValidation.js
+++ b/js/validation/postSearchValidation.js
@@ -1,0 +1,21 @@
+export class PostSearchValidation {
+  static validateSearchKeyword(keyword) {
+    if(!keyword){
+      return {
+        isValid: false,
+        errorMessage: "検索キーワードを入力してください。"
+      }
+    }
+    return { isValid: true };
+  }
+
+  static validateNotSearchPosts(filteredPosts) {
+    if (filteredPosts.length === 0) {
+      return {
+        isValid: false,
+        errorMessage: "指定されたキーワードに該当する投稿は見つかりませんでした。"
+      };
+    }
+    return { isValid: true };
+  }
+}

--- a/js/view/PostViewRenderer.js
+++ b/js/view/PostViewRenderer.js
@@ -106,6 +106,12 @@ export class PostViewRenderer {
     createPostContent.insertBefore(errorComment, setCommentContent);
   }
 
+  static addErrorMessageIntoSearch() {
+    const searchContent = this.getSearchContent();
+    const searchErrorMessageElem = this.createErrorCommentMessage();
+    searchContent.insertBefore(searchErrorMessageElem, searchContent.firstChild);
+  }
+
   static initErrorMessage(liElement) {
     const errorNameElem = this.getErrorNameElem(liElement);
     const errorCommentElem = this.getErrorCommentElem(liElement);
@@ -115,6 +121,14 @@ export class PostViewRenderer {
     errorCommentElem.style.display = "none";
   }
 
+  static initErrorMessageIntoSearchElem() {
+    const searchContent = this.getSearchContent();
+    const searchErrorMessageElem = this.getErrorCommentElem(searchContent);
+    if(searchErrorMessageElem) {
+      searchErrorMessageElem.remove();
+    }
+  }
+
   static showErrorMessage(errorElem, errorMessage) {
     errorElem.textContent = errorMessage;
     errorElem.style.display = "block";
@@ -122,6 +136,14 @@ export class PostViewRenderer {
 
   static getHtmlElem(getHtmlElemId) {
     return document.getElementById(getHtmlElemId);
+  }
+
+  static getSortSeletectElem() {
+    return document.getElementById("sortSelect");
+  }
+
+  static getSearchContent() {
+    return document.querySelector(".search");
   }
 
   static getCreatePostContent() {

--- a/js/view/PostViewRenderer.js
+++ b/js/view/PostViewRenderer.js
@@ -352,4 +352,12 @@ export class PostViewRenderer {
     const regex = new RegExp(`(${escapedKeyword})`, "gi");
     return text.replace(regex, `<mark>$1</mark>`);
   }
+
+  static clearValueElem(elem) {
+    elem.value = "";
+  }
+
+  static clearInnerHTML(elem) {
+    elem.innerHTML = "";
+  }
 }

--- a/js/view/PostViewRenderer.js
+++ b/js/view/PostViewRenderer.js
@@ -1,15 +1,15 @@
 export class PostViewRenderer {
-  static createSpanUserName(userName) {
+  static createSpanUserName(userName, keyword = "") {
     const spanUsername = document.createElement("span");
     spanUsername.className = "userName";
-    spanUsername.textContent = `${userName}さん`;
+    spanUsername.innerHTML = keyword ? `${this.highlightText(userName, keyword)}さん` : `${userName}さん`;
     return spanUsername;
   }
 
-  static createSpanComment(comment){
+  static createSpanComment(comment, keyword = "") {
     const spanComment = document.createElement("span");
     spanComment.className = "commentText";
-    spanComment.textContent = comment;
+    spanComment.innerHTML = keyword ? this.highlightText(comment, keyword) : comment;
     return spanComment;
   }
 
@@ -170,6 +170,20 @@ export class PostViewRenderer {
     return document.querySelectorAll(".editButton");
   }
 
+  static getPaginationContainer(){
+    return document.getElementById("paginationContainer")
+  }
+
+  static HiddenPagination() {
+    const paiginationContainer = this.getPaginationContainer();
+    paiginationContainer.style.display = "none";
+  }
+
+  static ShowPagination() {
+    const paiginationContainer = this.getPaginationContainer();
+    paiginationContainer.style.display = "";
+  }
+
   static switchEditMode(postKey, liElement) {
     const postContent = this.getPostContentElem(liElement);
     const postText = this.getPostTextElem(liElement);
@@ -269,5 +283,11 @@ export class PostViewRenderer {
       }
     });
     this.switchDisabledPostButton();
+  }
+
+  static highlightText(text, keyword) {
+    const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escapedKeyword})`, "gi");
+    return text.replace(regex, `<mark>$1</mark>`);
   }
 }

--- a/js/view/PostViewRenderer.js
+++ b/js/view/PostViewRenderer.js
@@ -319,6 +319,12 @@ export class PostViewRenderer {
     this.switchDisabledResetButton();
   }
 
+  static switchEnabledButtons() {
+    this.switchEnabledPostButton();
+    this.switchEnabledSearchButton();
+    this.switchEnabledResetButton();
+  }
+
   static highlightText(text, keyword) {
     const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(`(${escapedKeyword})`, "gi");

--- a/js/view/PostViewRenderer.js
+++ b/js/view/PostViewRenderer.js
@@ -174,6 +174,14 @@ export class PostViewRenderer {
     return document.getElementById("paginationContainer")
   }
 
+  static getSearchButton(){
+    return document.getElementById("searchButton");
+  }
+
+  static getResetButton(){
+    return document.getElementById("resetButton");
+  }
+
   static HiddenPagination() {
     const paiginationContainer = this.getPaginationContainer();
     paiginationContainer.style.display = "none";
@@ -267,6 +275,30 @@ export class PostViewRenderer {
     postButtonWrapper.classList.remove("disabled-button");
   }
 
+  static switchDisabledSearchButton() {
+    const searchButton = this.getSearchButton();
+    searchButton.disabled = true;
+    searchButton.classList.add("disabled-button");
+  }
+
+  static switchEnabledSearchButton() {
+    const searchButton = this.getSearchButton();
+    searchButton.disabled = false;
+    searchButton.classList.remove("disabled-button");
+  }
+
+  static switchDisabledResetButton() {
+    const resetButton = this.getResetButton();
+    resetButton.disabled = true;
+    resetButton.classList.add("disabled-button");
+  }
+
+  static switchEnabledResetButton() {
+    const resetButton = this.getResetButton();
+    resetButton.disabled = false;
+    resetButton.classList.remove("disabled-button");
+  }
+
   static switchDisabledButtons(postKey) {
     const deleteButtons = this.getDeleteButtons();
     const editButtons = this.getEditButtons();
@@ -283,6 +315,8 @@ export class PostViewRenderer {
       }
     });
     this.switchDisabledPostButton();
+    this.switchDisabledSearchButton();
+    this.switchDisabledResetButton();
   }
 
   static highlightText(text, keyword) {

--- a/js/view/PostViewRenderer.js
+++ b/js/view/PostViewRenderer.js
@@ -41,6 +41,14 @@ export class PostViewRenderer {
     return textAreaComment;
   }
 
+  static createLiElem() {
+    return document.createElement('li');
+  }
+
+  static createDivElem() {
+    return document.createElement('div');
+  }
+
   static createEditButton(postKey) {
     const editButton = document.createElement("button");
     editButton.type = "button";
@@ -110,6 +118,16 @@ export class PostViewRenderer {
     const searchContent = this.getSearchContent();
     const searchErrorMessageElem = this.createErrorCommentMessage();
     searchContent.insertBefore(searchErrorMessageElem, searchContent.firstChild);
+  }
+
+  static addSearchResultMessage(postListElem) {
+    const li = this.createLiElem();
+    const postContent = this.createDivElem();
+    postContent.className = 'postContent';
+    postContent.textContent = "指定されたキーワードに該当する投稿は見つかりませんでした。";
+    postContent.style.justifyContent = "center";
+    li.appendChild(postContent);
+    postListElem.insertBefore(li, postListElem.firstChild);
   }
 
   static initErrorMessage(liElement) {

--- a/js/view/PostViewRenderer.js
+++ b/js/view/PostViewRenderer.js
@@ -252,18 +252,22 @@ export class PostViewRenderer {
     postContent.replaceChild(cancelButton, postContent.querySelector(".deleteButton"));
   }
 
-  static switchTextMode(liElement) {
+  static switchTextMode(liElement, keyword = "") {
     const postContent = this.getPostContentElem(liElement);
     const postText = this.getPostTextElem(liElement);
-    
     const editUserName = this.getEditUserName(liElement);
     const editComment = this.getEditComment(liElement);
-    
+    const postKey = this.getPostKeyFromTarget(postContent.querySelector(".saveButton"));
+    const spanUsername = this.createSpanUserName(editUserName, keyword);
+    const spanComment = this.createSpanComment(editComment, keyword);
+    const editButton = this.createEditButton(postKey);
+    const deleteButton = this.createDeleteButton(postKey);
+
     postContent.removeChild(liElement.querySelector(".saveButton"));
     postContent.removeChild(liElement.querySelector(".cancelButton"));
 
-    const spanUsername = this.createSpanUserName(editUserName);
-    const spanComment = this.createSpanComment(editComment);
+    postContent.appendChild(editButton);
+    postContent.appendChild(deleteButton);
 
     postText.replaceChild(spanUsername, postText.querySelector(".editUserName"));
     postText.replaceChild(spanComment, postText.querySelector(".editCommentText"));
@@ -363,6 +367,20 @@ export class PostViewRenderer {
     this.switchEnabledPostButton();
     this.switchEnabledSearchButton();
     this.switchEnabledResetButton();
+  }
+
+  static switchEnabledAllButtons() {
+    const deleteButtons = this.getDeleteButtons();
+    const editButtons = this.getEditButtons();
+    deleteButtons.forEach(button => {
+      button.disabled = false;
+      button.classList.remove("disabled-button");
+    });
+    editButtons.forEach(button => {
+      button.disabled = false;
+      button.classList.remove("disabled-button");
+    });
+    this.switchEnabledButtons();
   }
 
   static highlightText(text, keyword) {


### PR DESCRIPTION
## 変更点
#### キーワード検索機能

- キーワードを入力して`検索`ボタンを押すと、ニックネームもしくはコメントで同一文字があった投稿を一覧表示した
- キーワードの箇所を黄色マーカーでハイライトを付けた
- キーワード検索した投稿の編集・削除をした後は検索結果一覧表示の状態を維持した
- `検索結果リセット`ボタンを押すと、全投稿の一覧表示状態に戻るようにした
- キーワード検索欄に入力がない、もしくは該当するキーワードが無かった場合エラーメッセージを表示した

#### 並び替え機能

- 投稿No.順で並び替えするようにした
- `新しい順`：最新の投稿が最後のページの先頭に表示
- `古い順`：一番古い投稿が最後のページの先頭に表示

## 残務

- 検索結果に対するページネーションの実装