### PR TITLE
並び替え・ページネーションの修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,8 @@
 @charset "utf-8";
+:root {
+  --pagination-height: 80px;
+}
+
 html {
   font-size: 62.5%;
 }
@@ -94,8 +98,13 @@ input[type="submit"]:disabled {
 }
 
 .posts {
-  margin-left: 10%;
   flex-direction: column;
+  padding-bottom: var(--pagination-height);
+}
+
+#postList {
+  margin: 0 10%;
+  width: auto;
 }
 
 ul {
@@ -209,10 +218,16 @@ li span {
 }
 
 #paginationContainer {
+  background-color: #f1ede5;
+  position: fixed;
+  bottom: 2%;
+  margin: 0;
+  width: 100%;
+  padding: 1rem;
   display: flex;
   justify-content: center;
   gap: 1rem;
-  margin-top: 3rem;
+  z-index: 1000;
 }
 
 #paginationContainer button {
@@ -244,7 +259,7 @@ li span {
 
 #pagination {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 1rem;
 }
 
@@ -389,6 +404,10 @@ html.dark li {
   border-color: #444;
 }
 
+html.dark #paginationContainer {
+  background-color: #1f1f1f;
+}
+
 html.dark .error {
   background-color: red !important;
   border-radius: 0 !important;
@@ -437,16 +456,29 @@ html.dark input[type="text"]:-webkit-autofill {
   #paginationContainer {
     justify-content: center;
     flex-direction: row;
+    gap: 0.5rem;
     align-items: center;
-    margin: 20px;
+    padding: 0.5rem;
   }
 
   #pagination {
     display: block;
     flex-wrap: wrap;
+    padding: 0.5rem;
+    font-size: 1.2rem;
+    min-width: 32px;
   }
+
+  #paginationContainer button {
+    padding: 0.5rem;
+    font-size: 1.2rem;
+    min-width: 32px;
+  }
+
   #pagination button { 
-    margin: 5px;
+    padding: 0.5rem;
+    font-size: 1.2rem;
+    min-width: 32px;
   }
 
   .postContent {

--- a/js/parts/postCreate.js
+++ b/js/parts/postCreate.js
@@ -45,9 +45,9 @@ export class PostCreate {
       this.userNameRepository.setUserName(userName);
     }
     this.postRepository.addComment(comment, userName);
-    this.postListController.allPosts = this.postRepository.getAllPosts();
-    const totalPages = this.postListController.paginator.totalPages(this.postListController.allPosts);
-    this.postListController.refreshPostList(totalPages);
+    this.postListController.setSortOrder("newest");
+    PostViewRenderer.switchToNewest();
+    this.postListController.refreshPostList(1);
     this.postListController.paginator.updateRefreshFunction(page => this.postListController.refreshPostList(page));
     PostViewRenderer.clearValueElem(this.commentInput);
   }

--- a/js/postListController.js
+++ b/js/postListController.js
@@ -18,7 +18,7 @@ export class PostListController{
       page => this.refreshPostList(page)
     );
     this.allPosts = this.postRepository.getAllPosts();
-    this.currentPage = this.paginator.totalPages(this.allPosts);
+    this.currentPage = 1;
     this.sortOrder = "newest";
     this.refreshPostList(this.currentPage);
   }
@@ -43,8 +43,7 @@ export class PostListController{
     postContent.appendChild(editButton);
     postContent.appendChild(deleteButton);
     li.appendChild(postContent);
-  
-    this.postList.insertBefore(li, this.postList.firstChild);
+    this.postList.appendChild(li);
   }
 
   loadCurrentPagePosts(page){
@@ -78,18 +77,18 @@ export class PostListController{
 
       if (!aHasDate && !bHasDate) {
         return this.sortOrder === "oldest"
-          ? b.postNum - a.postNum
-          : a.postNum - b.postNum;
+          ? a.postNum - b.postNum
+          : b.postNum - a.postNum;
       }
-      if (!aHasDate) return this.sortOrder === "oldest" ? 1 : -1;
-      if (!bHasDate) return this.sortOrder === "oldest" ? -1 : 1;
+      if (!aHasDate) return this.sortOrder === "oldest" ? -1 : 1;
+      if (!bHasDate) return this.sortOrder === "oldest" ? 1 : -1;
 
       const aDate = new Date(a.createdAt);
       const bDate = new Date(b.createdAt);
   
       return this.sortOrder === "oldest"
-        ? bDate - aDate
-        : aDate - bDate;
+        ? aDate - bDate
+        : bDate - aDate;
     });
   }
 

--- a/js/view/PostViewRenderer.js
+++ b/js/view/PostViewRenderer.js
@@ -173,6 +173,11 @@ export class PostViewRenderer {
     return document.getElementById("sortSelect");
   }
 
+  static switchToNewest() {
+    const sortSelect = this.getSortSeletectElem();
+    sortSelect.value = "newest";
+  }
+
   static getSearchContent() {
     return document.querySelector(".search");
   }


### PR DESCRIPTION
## 変更点

- 表示されるコメントのページ、順番を１ページ目に並び替えた先頭の投稿が表示されるように修正した。
- 例：１→２→３→４→５→６→７→８→９→１０と投稿した時
　　　＜新しい順＞
　　　・１ページ目：１０→９→８→７→６
　　　・２ページ目：５→４→３→２→１
　　　＜古い順＞
　　　・１ページ目：１→２→３→４→５
　　　・２ページ目：６→７→８→９→１０
- 新規投稿をした場合、並び替えは＜新しい順＞にリセットされ、１ページ目が表示されるようにした
- ページネーションが画面の下部あたりに固定されるようにした